### PR TITLE
在指定的js安全域中的url获取问题

### DIFF
--- a/config/wechat.cfg.js
+++ b/config/wechat.cfg.js
@@ -1,7 +1,7 @@
 module.exports = {
 	grant_type: 'client_credential',
-	appid: 'xxxxxxxxxxxxxxxxxx',
-	secret: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	appid: 'wxf8337b6f556b0bb8',
+	secret: 'cd8fccf9052a3bccae25f3fa398fe44c',
 	noncestr:'Wm3WZYTPz0wzccnW',
 	accessTokenUrl:'https://api.weixin.qq.com/cgi-bin/token',
 	ticketUrl:'https://api.weixin.qq.com/cgi-bin/ticket/getticket',

--- a/router/index.js
+++ b/router/index.js
@@ -8,7 +8,16 @@ exports.init = function (app) {
 
 	
 	app.get('/',function(req,res){
-		var url = req.protocol + '://' + req.host + req.path; //获取当前url
+		var url = req.protocol + '://' + req.host + req.originalUrl; //获取当前url
+		signature.sign(url,function(signatureMap){
+			signatureMap.appId = wechat_cfg.appid;
+			res.render('index',signatureMap);
+		});
+	});
+
+	app.get('/wx', function(req,res){
+		var url = req.protocol + '://' + req.host + req.originalUrl; //获取当前url
+		console.log('url ======########======= ', url);
 		signature.sign(url,function(signatureMap){
 			signatureMap.appId = wechat_cfg.appid;
 			res.render('index',signatureMap);

--- a/router/index.js
+++ b/router/index.js
@@ -8,7 +8,7 @@ exports.init = function (app) {
 
 	
 	app.get('/',function(req,res){
-		var url = req.protocol + '://' + req.host + req.path; //获取当前url
+		var url = req.protocol + '://' + req.host + req.originalUrl; //获取当前url 包含?后的但不包含#号后的
 		signature.sign(url,function(signatureMap){
 			signatureMap.appId = wechat_cfg.appid;
 			res.render('index',signatureMap);

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ app.set('views', './views');  // 设置模板相对路径(相对当前目录)
 
 app.locals.basedir = './'
 
-var port = 18080 ;  //BAE 百度应用引擎默认端口号
+var port = 4567 ;  //BAE 百度应用引擎默认端口号
  //中间件定义
 app.use(express.logger());
 app.use(express.compress());

--- a/static/wx/index.css
+++ b/static/wx/index.css
@@ -1,0 +1,17 @@
+body{-webkit-tap-highlight-color: rgba(0,0,0,0);}
+h3{text-align: center;color: red;}
+.panel{text-align: center;}
+.panel h5{
+	text-align: left;
+	color: #888;
+	margin: 0;
+}
+.panel button{
+	width: 90%;
+	height: 40px;
+	line-height: 40px;
+	margin: 5px auto;
+	border: none;
+	border-radius: 5px;
+	background: #e2e2e2;
+}

--- a/static/wx/index.js
+++ b/static/wx/index.js
@@ -1,0 +1,136 @@
+document.getElementById('refresh').onclick = function(){location.reload();}
+
+/**
+ *  以下内容多摘自官方demo
+ *
+**/
+wx.config({
+    debug: true, // 开启调试模式,调用的所有api的返回值会在客户端alert出来，若要查看传入的参数，可以在pc端打开，参数信息会通过log打出，仅在pc端时才会打印。
+    appId: appId, // 必填，公众号的唯一标识
+    timestamp: timestamp, // 必填，生成签名的时间戳
+    nonceStr: nonceStr, // 必填，生成签名的随机串
+    signature: signature,// 必填，签名，见附录1
+    jsApiList: ['checkJsApi',
+        'onMenuShareTimeline',
+        'onMenuShareAppMessage',
+        'onMenuShareQQ',
+        'onMenuShareWeibo',
+        'hideMenuItems',
+        'showMenuItems',
+        'hideAllNonBaseMenuItem',
+        'showAllNonBaseMenuItem',
+        'translateVoice',
+        'startRecord',
+        'stopRecord',
+        'onRecordEnd',
+        'playVoice',
+        'pauseVoice',
+        'stopVoice',
+        'uploadVoice',
+        'downloadVoice',
+        'chooseImage',
+        'previewImage',
+        'uploadImage',
+        'downloadImage',
+        'getNetworkType',
+        'openLocation',
+        'getLocation',
+        'hideOptionMenu',
+        'showOptionMenu',
+        'closeWindow',
+        'scanQRCode',
+        'chooseWXPay',
+        'openProductSpecificView',
+        'addCard',
+        'chooseCard',
+        'openCard'] // 必填，需要使用的JS接口列表，
+});
+
+wx.ready(function(){
+ // 1 判断当前版本是否支持指定 JS 接口，支持批量判断
+  document.querySelector('#checkJsApi').onclick = function () {
+    wx.checkJsApi({
+      jsApiList: [
+        'getNetworkType',
+        'previewImage'
+      ],
+      success: function (res) {
+        alert(JSON.stringify(res));
+      }
+    });
+  };
+
+   // 2. 分享接口
+  // 2.1 监听“分享给朋友”，按钮点击、自定义分享内容及分享结果接口
+  document.querySelector('#onMenuShareAppMessage').onclick = function () {
+    wx.onMenuShareAppMessage({
+      title: '互联网之子',
+      desc: '在长大的过程中，我才慢慢发现，我身边的所有事，别人跟我说的所有事，那些所谓本来如此，注定如此的事，它们其实没有非得如此，事情是可以改变的。更重要的是，有些事既然错了，那就该做出改变。',
+      link: 'http://movie.douban.com/subject/25785114/',
+      imgUrl: 'http://demo.open.weixin.qq.com/jssdk/images/p2166127561.jpg',
+      trigger: function (res) {
+        // 不要尝试在trigger中使用ajax异步请求修改本次分享的内容，因为客户端分享操作是一个同步操作，这时候使用ajax的回包会还没有返回
+        alert('用户点击发送给朋友');
+      },
+      success: function (res) {
+        alert('已分享');
+      },
+      cancel: function (res) {
+        alert('已取消');
+      },
+      fail: function (res) {
+        alert(JSON.stringify(res));
+      }
+    });
+    alert('已注册获取“发送给朋友”状态事件');
+  };
+
+    // 5 图片接口
+  // 5.1 拍照、本地选图
+  var images = {
+    localId: [],
+    serverId: []
+  };
+  document.querySelector('#chooseImage').onclick = function () {
+    wx.chooseImage({
+      success: function (res) {
+        images.localId = res.localIds;
+        alert('已选择 ' + res.localIds.length + ' 张图片');
+      }
+    });
+  };
+    // 5.2 图片预览
+  document.querySelector('#previewImage').onclick = function () {
+    wx.previewImage({
+      current: 'http://img5.douban.com/view/photo/photo/public/p1353993776.jpg',
+      urls: [
+        'http://img3.douban.com/view/photo/photo/public/p2152117150.jpg',
+        'http://img5.douban.com/view/photo/photo/public/p1353993776.jpg',
+        'http://img3.douban.com/view/photo/photo/public/p2152134700.jpg'
+      ]
+    });
+  };
+
+    // 7.2 获取当前地理位置
+  document.querySelector('#getLocation').onclick = function () {
+    wx.getLocation({
+      success: function (res) {
+        alert(JSON.stringify(res));
+      },
+      cancel: function (res) {
+        alert('用户拒绝授权获取地理位置');
+      }
+    });
+  };
+
+    // 9 微信原生接口
+  // 9.1.1 扫描二维码并返回结果
+  document.querySelector('#scanQRCode0').onclick = function () {
+    wx.scanQRCode();
+  };
+
+});
+
+wx.error(function(res){
+	JSON.stringify(res)
+});

--- a/views/index.jade
+++ b/views/index.jade
@@ -5,7 +5,7 @@ html(lang='en')
 		meta(name='viewport',content='width=device-width,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no,minimal-ui')
 		meta(name='apple-mobile-web-app-status-bar-style',content='black')
 		title 微信SDK demo
-		link(rel='stylesheet',type="text/css",href='/index.css')
+		link(rel='stylesheet',type="text/css",href='index.css')
 	body
 		h3 微信SDK demo
 		div.panel
@@ -39,4 +39,4 @@ html(lang='en')
 			var timestamp = '#{timestamp}';
 			var appId = '#{appId}';
 			var jsapi_ticket = '#{jsapi_ticket}';
-		script(src='/index.js')
+		script(src='index.js')


### PR DESCRIPTION
测试发现，如果js的安全域时xxx.com的话，xxx.com可用，但xxx.com?a=b就会出现问题，签名时当前url需要包含?后的内容单不包含#号后的内容，用`req.originalUrl`正合适。

参考：[微信 JS 接口签名校验工具](http://mp.weixin.qq.com/debug/cgi-bin/sandbox?t=jsapisign)
